### PR TITLE
Add PA Section to Claims Denials Analyses

### DIFF
--- a/investigations/claims_denials/pa_claims.ipynb
+++ b/investigations/claims_denials/pa_claims.ipynb
@@ -351,6 +351,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Logic for extracting data from public records\n",
+    "# Horrible, but it got the job done, and can ideally be re-used for future records requests.\n",
     "# data_dir = \"/home/mike/persius/Public Records Request/PA/rtkl01609\"\n",
     "# pdf_paths = glob.glob(f\"{data_dir}/**\")\n",
     "\n",


### PR DESCRIPTION
These commits add an initial, minimal analysis of PA claims denial data obtained via a public records request.